### PR TITLE
default environment file for container ports

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+sdaasport=9999
+apiport=8080
+lodviewport=8082
+lodeport=8083
+routerport=80


### PR DESCRIPTION
you can overwrite these values by setting the environment variable before you launch docker-compose -f docker-compose-run.yml up